### PR TITLE
feat(unidade): Implementar funcionalidade de CRUD para Unidade

### DIFF
--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/controller/BlocoController.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/controller/BlocoController.java
@@ -1,8 +1,8 @@
 package br.edu.infnet.sentinella_matheus_maciel_api.controller;
 
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosAtualizacaoBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosCadastroBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosListagemBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosAtualizacaoBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosCadastroBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosListagemBlocoDTO;
 import br.edu.infnet.sentinella_matheus_maciel_api.service.BlocoService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/controller/UnidadeController.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/controller/UnidadeController.java
@@ -1,0 +1,51 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.controller;
+
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosAtualizacaoUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosCadastroUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosListagemUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.service.UnidadeService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/unidades")
+public class UnidadeController {
+
+    private final UnidadeService unidadeService;
+
+    public UnidadeController(UnidadeService unidadeService){
+        this.unidadeService = unidadeService;
+    }
+
+    @PostMapping
+    public ResponseEntity<DadosListagemUnidadeDTO> cadastrar(@RequestBody @Valid DadosCadastroUnidadeDTO dados, UriComponentsBuilder uriBuilder){
+
+        var dadosUnidadeCadastrada = unidadeService.cadastrar(dados);
+        var uri = uriBuilder.path("/unidades/{id}").buildAndExpand(dadosUnidadeCadastrada.id()).toUri();
+
+        return ResponseEntity.created(uri).body(dadosUnidadeCadastrada);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<DadosListagemUnidadeDTO>> listar(){
+        var listaDeUnidades = unidadeService.listarTodas();
+        return ResponseEntity.ok(listaDeUnidades);
+    }
+
+    @PutMapping
+    public ResponseEntity<DadosListagemUnidadeDTO> atualizar(@RequestBody @Valid DadosAtualizacaoUnidadeDTO dados){
+        var dadosUnidadeAtualizada = unidadeService.atualizar(dados);
+        return ResponseEntity.ok(dadosUnidadeAtualizada);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> excluir(@PathVariable Long id){
+        unidadeService.excluir(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosAtualizacaoBlocoDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosAtualizacaoBlocoDTO.java
@@ -1,4 +1,4 @@
-package br.edu.infnet.sentinella_matheus_maciel_api.dto;
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosCadastroBlocoDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosCadastroBlocoDTO.java
@@ -1,4 +1,4 @@
-package br.edu.infnet.sentinella_matheus_maciel_api.dto;
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosListagemBlocoDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/bloco/DadosListagemBlocoDTO.java
@@ -1,10 +1,10 @@
-package br.edu.infnet.sentinella_matheus_maciel_api.dto;
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco;
 
 import br.edu.infnet.sentinella_matheus_maciel_api.model.domain.Bloco;
 
 public record DadosListagemBlocoDTO(
-    Long id,
-    String nome
+        Long id,
+        String nome
 ) {
     public DadosListagemBlocoDTO(Bloco bloco) {
         this(bloco.getId(), bloco.getNome());

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosAtualizacaoUnidadeDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosAtualizacaoUnidadeDTO.java
@@ -1,0 +1,12 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DadosAtualizacaoUnidadeDTO(
+        @NotNull
+        Long id,
+        String numero,
+        String descricao,
+        Long blocoId
+) {
+}

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosCadastroUnidadeDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosCadastroUnidadeDTO.java
@@ -1,0 +1,15 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DadosCadastroUnidadeDTO(
+        @NotBlank
+        String numero,
+
+        String descricao,
+
+        @NotNull
+        Long blocoId
+) {
+}

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosListagemUnidadeDTO.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/dto/unidade/DadosListagemUnidadeDTO.java
@@ -1,0 +1,19 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade;
+
+import br.edu.infnet.sentinella_matheus_maciel_api.model.domain.Unidade;
+
+public record DadosListagemUnidadeDTO(
+        Long id,
+        String numero,
+        String descricao,
+        Long blocoId,
+        String blocoNome
+) {
+    public DadosListagemUnidadeDTO(Unidade unidade){
+        this(unidade.getId(),
+                unidade.getNumero(),
+                unidade.getDescricao(),
+                unidade.getBloco().getId(),
+                unidade.getBloco().getNome());
+    }
+}

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/model/domain/Unidade.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/model/domain/Unidade.java
@@ -1,14 +1,12 @@
 package br.edu.infnet.sentinella_matheus_maciel_api.model.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity(name = "Unidade")
 @Table(name = "unidades")
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/BlocoService.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/BlocoService.java
@@ -1,8 +1,13 @@
 package br.edu.infnet.sentinella_matheus_maciel_api.service;
 
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosAtualizacaoBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosCadastroBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosListagemBlocoDTO;
+
+
+
+
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosAtualizacaoBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosCadastroBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosListagemBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.model.domain.Bloco;
 
 import java.util.List;
 
@@ -16,5 +21,7 @@ public interface BlocoService {
     DadosListagemBlocoDTO atualizar(DadosAtualizacaoBlocoDTO dados);
 
     void excluir(Long id);
+
+    Bloco buscarPorId(Long id);
 
 }

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/BlocoServiceImpl.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/BlocoServiceImpl.java
@@ -1,8 +1,10 @@
 package br.edu.infnet.sentinella_matheus_maciel_api.service;
 
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosAtualizacaoBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosCadastroBlocoDTO;
-import br.edu.infnet.sentinella_matheus_maciel_api.dto.DadosListagemBlocoDTO;
+
+
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosAtualizacaoBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosCadastroBlocoDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.bloco.DadosListagemBlocoDTO;
 import br.edu.infnet.sentinella_matheus_maciel_api.model.domain.Bloco;
 import br.edu.infnet.sentinella_matheus_maciel_api.repository.BlocoRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -58,6 +60,12 @@ public class BlocoServiceImpl implements BlocoService {
         }
 
         repository.deleteById(id);
+    }
+
+    @Override
+    public Bloco buscarPorId(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Bloco não encontrado com o id: " + id));
     }
 
 

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/UnidadeService.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/UnidadeService.java
@@ -1,0 +1,16 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.service;
+
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosCadastroUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosAtualizacaoUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosListagemUnidadeDTO;
+
+import java.util.List;
+
+public interface UnidadeService {
+
+    DadosListagemUnidadeDTO cadastrar(DadosCadastroUnidadeDTO dados);
+    List<DadosListagemUnidadeDTO> listarTodas();
+    DadosListagemUnidadeDTO atualizar(DadosAtualizacaoUnidadeDTO dados);
+    void excluir(Long id);
+
+}

--- a/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/UnidadeServiceImpl.java
+++ b/src/main/java/br/edu/infnet/sentinella_matheus_maciel_api/service/UnidadeServiceImpl.java
@@ -1,0 +1,72 @@
+package br.edu.infnet.sentinella_matheus_maciel_api.service;
+
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosAtualizacaoUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosCadastroUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.dto.unidade.DadosListagemUnidadeDTO;
+import br.edu.infnet.sentinella_matheus_maciel_api.model.domain.Unidade;
+import br.edu.infnet.sentinella_matheus_maciel_api.repository.UnidadeRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class UnidadeServiceImpl implements UnidadeService{
+
+    private final UnidadeRepository unidadeRepository;
+    private final BlocoService blocoService;
+
+    public UnidadeServiceImpl(UnidadeRepository unidadeRepository, BlocoService blocoService){
+        this.unidadeRepository = unidadeRepository;
+        this.blocoService = blocoService;
+    }
+
+    @Override
+    @Transactional
+    public DadosListagemUnidadeDTO cadastrar(DadosCadastroUnidadeDTO dados) {
+
+        var bloco = blocoService.buscarPorId(dados.blocoId());
+        var unidade = new Unidade(null, dados.numero(), dados.descricao(), bloco);
+        unidadeRepository.save(unidade);
+
+        return new DadosListagemUnidadeDTO(unidade);
+    }
+
+    @Override
+    public List<DadosListagemUnidadeDTO> listarTodas() {
+        return unidadeRepository.findAll()
+                .stream()
+                .map(DadosListagemUnidadeDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public DadosListagemUnidadeDTO atualizar(DadosAtualizacaoUnidadeDTO dados) {
+        var unidade = unidadeRepository.findById(dados.id())
+                .orElseThrow(() -> new EntityNotFoundException("Unidade com ID " + dados.id() + " não encontrada."));
+
+            Optional.ofNullable(dados.numero()).ifPresent(unidade::setNumero);
+            Optional.ofNullable(dados.descricao()).ifPresent(unidade::setDescricao);
+
+            Optional.ofNullable(dados.blocoId()).ifPresent(blocoId -> {
+                var bloco = blocoService.buscarPorId(blocoId);
+                unidade.setBloco(bloco);
+            });
+            return new DadosListagemUnidadeDTO(unidade);
+    }
+
+    @Override
+    @Transactional
+    public void excluir(Long id) {
+
+        if(!unidadeRepository.existsById(id)){
+            throw new EntityNotFoundException("Unidade com ID " + id + " não encontrada.");
+        }
+
+        unidadeRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
Este commit introduz o ciclo de vida completo (CRUD) para a entidade Unidade, concluindo a História de Usuário 1.2.

- Criado `UnidadeController` com endpoints para POST, GET, PUT e DELETE no recurso `/unidades`.
- Implementado `UnidadeService` com a lógica de negócio para criar, listar, atualizar e excluir unidades.
- O `UnidadeService` agora se comunica com o `BlocoService` para validar e associar o bloco correspondente, respeitando os limites de responsabilidade entre serviços.
- Adicionados DTOs específicos para Unidade (`DadosCadastroUnidadeDTO`, `DadosListagemUnidadeDTO`, `DadosAtualizacaoUnidadeDTO`) que lidam com a referência ao `blocoId` na entrada de dados e enriquecem a saída com o nome do bloco.